### PR TITLE
Convert outdated INLA mesh code to fmesher calls

### DIFF
--- a/.github/workflows/R-CMD-check-no-suggests.yaml
+++ b/.github/workflows/R-CMD-check-no-suggests.yaml
@@ -36,7 +36,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -60,31 +60,98 @@ jobs:
         run: |
           sudo apt-get update -y && sudo apt-get install -y libglu1-mesa-dev
 
-      - name: Has inla? Check.
+      - name: Has Suggests?
         run: |
           options(width = 100)
           pkgs <- installed.packages()[, "Package"]
-          "INLA" %in% pkgs
+          sug <- as.list(read.dcf("DESCRIPTION")[1,])$Suggests
+          sug <- gsub(" \\([^)]*\\)", "", sug)
+          sug <- gsub("\n", "", sug)
+          sug <- gsub(" ", "", sug)
+          sug <- strsplit(sug, ",")[[1]]
+          cat(paste0("Uninstalled Suggests: ",
+                     paste0(sug[!(sug %in% pkgs)], collapse = ", "),
+                     "\n"))
+          cat(paste0("Installed Suggests: ",
+                     paste0(sug[sug %in% pkgs], collapse = ", "),
+                     "\n"))
         shell: Rscript {0}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: '"hard"'
+          cache: false
           extra-packages: |
              rcmdcheck
              testthat
+             remotes
 
-      - name: Has inla? Check, and remove.
+      - name: Has Suggests? Remove INLA.
         run: |
           options(width = 100)
           pkgs <- installed.packages()[, "Package"]
           "INLA" %in% pkgs
           if ("INLA" %in% pkgs) {
+            cat("Uninstalling INLA\n")
             remove.packages("INLA")
           }
+          pkgs <- installed.packages()[, "Package"]
+          sug <- as.list(read.dcf("DESCRIPTION")[1,])$Suggests
+          sug <- gsub(" \\([^)]*\\)", "", sug)
+          sug <- gsub("\n", "", sug)
+          sug <- gsub(" ", "", sug)
+          sug <- strsplit(sug, ",")[[1]]
+          cat(paste0("Uninstalled Suggests: ",
+                     paste0(sug[!(sug %in% pkgs)], collapse = ", "),
+                     "\n"))
+          cat(paste0("Installed Suggests: ",
+                     paste0(sug[sug %in% pkgs], collapse = ", "),
+                     "\n"))
         shell: Rscript {0}
 
-      - name: Session info
+      - name: Session info without INLA
+        run: |
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v2
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          _R_CHECK_FORCE_SUGGESTS_: false
+        with:
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          args: 'c("--no-manual", "--ignore-vignettes", "--as-cran")'
+
+      - name: Has Suggests? Ensure INLA installed.
+        run: |
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          if (!("INLA" %in% pkgs)) {
+            cat("Installing INLA\n")
+            install.packages("INLA")
+          }
+          pkgs <- installed.packages()[, "Package"]
+          sug <- as.list(read.dcf("DESCRIPTION")[1,])$Suggests
+          sug <- gsub(" \\([^)]*\\)", "", sug)
+          sug <- gsub("\n", "", sug)
+          sug <- gsub(" ", "", sug)
+          sug <- strsplit(sug, ",")[[1]]
+          cat(paste0("Uninstalled Suggests: ",
+                     paste0(sug[!(sug %in% pkgs)], collapse = ", "),
+                     "\n"))
+          cat(paste0("Installed Suggests: ",
+                     paste0(sug[sug %in% pkgs], collapse = ", "),
+                     "\n"))
+        shell: Rscript {0}
+
+      - name: Fix temporary out-of-sync binary packages
+        run: |
+          install.packages("MatrixModels", repos = "https://cloud.r-project.org", type = "source")
+        shell: Rscript {0}
+
+      - name: Session info with INLA
         run: |
           options(width = 100)
           pkgs <- installed.packages()[, "Package"]

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,7 +36,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: INLAspacetime
 Type: Package
 Title: Spatial and Spatio-Temporal Models using 'INLA'
-Version: 0.1.12.001
+Version: 0.1.12.002
 Authors@R: c(
   person("Elias Teixeira", "Krainski", email = "eliaskrainski@gmail.com",
          role = c("cre", "aut", "cph"), 

--- a/R/mesh2d.R
+++ b/R/mesh2d.R
@@ -10,8 +10,9 @@
 #' @param offset the length of the outer extension.
 #' @param SP logical indicating if the output will include the SpatialPolygons.
 #' @section Warning:
-#'  This is just for illustration purpose and one should consider the
-#'  efficient function available a the INLA package.
+#'  This is just for illustration purposes and one should consider the
+#'  efficient function [fmesher::fm_mesh_2d()] (and other related functions)
+#'  available a the fmesher package.
 #' @return a mesh object.
 #' @export
 mesh2d <-
@@ -154,6 +155,7 @@ mesh2d <-
     ))
     triang$segm$bnd$grp <- matrix(0, nrow(triang$segm$bnd$idx), 1)
     triang$segm$bnd$is.bnd <- TRUE
+    # NOTE: outdated class name, may be unsupported
     attr(triang$segm$bnd, "class") <- "inla.mesh.segment"
     if (SP) {
       triang$SP <- sp::SpatialPolygons(
@@ -166,6 +168,7 @@ mesh2d <-
       triang$centroids <- sp::coordinates(triang$SP)
     }
     triang$loc <- cbind(triang$loc, 0)
+    # NOTE: outdated class name, may be unsupported
     attr(triang, "class") <- "inla.mesh"
     return(triang)
   }

--- a/R/mesh2fem.R
+++ b/R/mesh2fem.R
@@ -116,7 +116,7 @@ mesh2fem.barrier <- function(mesh, barrier.triangles = NULL) {
 
   if(TRUE) {
     ### safe to use from triangle area from:
-    hh <- INLA::inla.mesh.fem(mesh, order = 1)$ta
+    hh <- fm_fem(mesh, order = 1)$ta
   } else {
     if(Rmanifold==0) {
       R.i <- sqrt(rowSums(mesh$loc^2))

--- a/R/mesh2projector.R
+++ b/R/mesh2projector.R
@@ -9,8 +9,8 @@
 #' @param dims the number of subdivisions over each boundary limits.
 #' @section Warning:
 #'  This is just for illustration purpose and one should consider the
-#'  efficient functions available in the INLA and inlabru packages,
-#'  e.g. `inlabru::fm_evaluator`.
+#'  efficient functions available in the fmesher package,
+#'  e.g. [fmesher::fm_evaluator()] and [fmesher::fm_basis()].
 #' @return the projector matrix as a list with sparse matrix object at `x$proj$A`..
 #' @export
 mesh2projector <- function(mesh, loc = NULL, lattice = NULL,
@@ -62,8 +62,10 @@ mesh2projector <- function(mesh, loc = NULL, lattice = NULL,
       grp = matrix(as.integer(1), ns, 1),
       is.bnd = TRUE, crs = NULL
     )
+    # NOTE: outdated class name, may be unsupported
     attr(res$lattice$segm, "class") <- "inla.mesh.segment"
     res$crs <- NULL
+    # NOTE: outdated class name, may be unsupported
     attr(res$lattice, "class") <- "inla.mesh.lattice"
     res$loc <- NULL
     m <- prod(dims)

--- a/R/stModel.matrices.R
+++ b/R/stModel.matrices.R
@@ -86,8 +86,8 @@ stModel.precision <-
 #' @importFrom fmesher fm_fem
 stModel.matrices <-
   function(smesh, tmesh, model, constr = FALSE) {
-    stopifnot(inherits(smesh, "inla.mesh"))
-    stopifnot(inherits(tmesh, "inla.mesh.1d"))
+    stopifnot(inherits(smesh, "fm_mesh_2d"))
+    stopifnot(inherits(tmesh, "fm_mesh_1d"))
     stopifnot(nchar(model) == 3)
     stopifnot(model %in% c("102", "121", "202", "220"))
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -155,6 +155,16 @@ Aproj <- inla.spde.make.A(
     group.mesh = tmesh
 )
 ```
+or, equivalently, with `fmesher` methods for tensor product spaces:
+```{r Aproj-fmesher,eval=FALSE}
+Aproj <- fm_basis(
+  fm_tensor(list(space = smesh, time = tmesh)),
+  loc = list(
+    space = cbind(dataf$s1, dataf$s2),
+    time = dataf$time
+  )
+)
+```
 
 Create a 'fake' column to be used as index. 
 in the `f()` term
@@ -229,3 +239,5 @@ Summary of the model parameters
 result$summary.fixed
 result$summary.hyperpar
 ```
+Note: The default prior for the intercept in inlabru has smaller variance than
+the default for INLA, which explains the slight difference in the results.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ Aproj <- inla.spde.make.A(
 )
 ```
 
+or, equivalently, with `fmesher` methods for tensor product spaces:
+
+``` r
+Aproj <- fm_basis(
+  fm_tensor(list(space = smesh, time = tmesh)),
+  loc = list(
+    space = cbind(dataf$s1, dataf$s2),
+    time = dataf$time
+  )
+)
+```
+
 Create a ‘fake’ column to be used as index. in the `f()` term
 
 ``` r
@@ -182,13 +194,13 @@ that were not fixed.
 ``` r
 fit$summary.fixed
 #>                  mean       sd 0.025quant  0.5quant 0.975quant      mode
-#> (Intercept) 0.6933668 4.032632  -6.962326 0.5227007   9.417351 0.5550529
+#> (Intercept) 0.6934075 4.032682  -6.962392 0.5227421   9.417461 0.5550903
 #>                      kld
-#> (Intercept) 7.400751e-05
+#> (Intercept) 7.405581e-05
 fit$summary.hyperpar
 #>                   mean        sd 0.025quant 0.5quant 0.975quant      mode
-#> Theta1 for st 1.199217 0.4918440  0.3653973 1.161533   2.277373 0.9749839
-#> Theta2 for st 1.435516 0.1710677  1.1031073 1.434032   1.776663 1.4277583
+#> Theta1 for st 1.199208 0.4918283  0.3653922 1.161532   2.277316 0.9750207
+#> Theta2 for st 1.435517 0.1710709  1.1031068 1.434032   1.776675 1.4277508
 ```
 
 ## Using the **inlabru**
@@ -228,12 +240,16 @@ Summary of the model parameters
 
 ``` r
 result$summary.fixed
-#>               mean       sd 0.025quant  0.5quant 0.975quant      mode
-#> Intercept 0.669205 3.969787  -6.886287 0.5096847   9.213137 0.5381091
+#>                mean       sd 0.025quant  0.5quant 0.975quant      mode
+#> Intercept 0.6690758 3.969868  -6.886579 0.5095548   9.213222 0.5379881
 #>                    kld
-#> Intercept 5.715402e-05
+#> Intercept 5.712418e-05
 result$summary.hyperpar
 #>                      mean        sd 0.025quant 0.5quant 0.975quant      mode
-#> Theta1 for field 1.190339 0.4867863  0.3623461 1.153751   2.255653 0.9727664
-#> Theta2 for field 1.435290 0.1709632  1.1035761 1.433643   1.776718 1.4266617
+#> Theta1 for field 1.190358 0.4867880   0.362423 1.153755   2.255714 0.9726899
+#> Theta2 for field 1.435283 0.1709765   1.103480 1.433658   1.776675 1.4267684
 ```
+
+Note: The default prior for the intercept in inlabru has smaller
+variance than the default for INLA, which explains the slight difference
+in the results.

--- a/inst/examples/simulated.R
+++ b/inst/examples/simulated.R
@@ -8,7 +8,7 @@ library(sf)
 if(Sys.info()["user"]=="eliask") {
     inla.setOption(
         inla.call = "remote",
-        num.threads = "8:1", 
+        num.threads = "8:1",
 ##        pardiso.license = "~/.pardiso.lic",
         safe = FALSE
         )
@@ -27,7 +27,7 @@ domain <- cbind(
     y = bb[c(2, 2, 4, 4, 2)])
 
 ## spatial mesh
-smesh <- inla.mesh.2d(
+smesh <- fm_mesh_2d(
     loc.domain = domain,
     offset = r0 / c(40, 3),
     max.edge = r0 / c(20, 5),
@@ -38,7 +38,7 @@ if(FALSE)
     plot(smesh)
 
 ## temporal mesh
-tmesh <- inla.mesh.1d(
+tmesh <- fm_mesh_1d(
     loc = 1:nt)
 
 ## model parameters
@@ -77,7 +77,7 @@ rm(.gammas, .b, .tt, .dxx, .d)
 if(FALSE)
     image(qq)
 
-## sample 
+## sample
 xx <- inla.qsample(n = 1, Q = qq)
 
 ns <- 1000 ## number locations in space

--- a/inst/examples/test0.R
+++ b/inst/examples/test0.R
@@ -5,8 +5,8 @@ library(inlabru)
 ### We need a plain test-example...
 inla.setOption(smtp='taucs', inla.mode='compact')
 
-smesh <- inla.mesh.2d(cbind(0,0), max.edge=5, offset=2)
-tmesh <- inla.mesh.1d(0:5)
+smesh <- fm_mesh_2d(cbind(0,0), max.edge=5, offset=2)
+tmesh <- fm_mesh_1d(0:5)
 
 n <- 5
 dataf <- data.frame(
@@ -23,7 +23,7 @@ M <- ~ -1 + Intercept(1) +
 
 ### define the spacetime model
 stmodel <- stModel.define(
-    smesh, tmesh, '121', 
+    smesh, tmesh, '121',
     control.priors=list(
         prs=c(1, NA), ## fix spatial range to 1
         prt=c(5, 0.0),## fix temporal range to 5
@@ -37,12 +37,12 @@ cat("Number of non-zeros in Q_u:",
 lkprec <- list(prec=list(initial=10, fixed=TRUE))
 
 ### fit
-result <- 
-    bru(M, 
-        like(formula = y ~ ., 
+result <-
+    bru(M,
+        like(formula = y ~ .,
              family="gaussian",
              control.family = list(
-                 hyper = lkprec), 
+                 hyper = lkprec),
              data=dataf),
         options = list(
             verbose=TRUE)

--- a/inst/examples/test4.R
+++ b/inst/examples/test4.R
@@ -5,8 +5,8 @@ library(inlabru)
 ### We need a plain test-example...
 inla.setOption(smtp='taucs', inla.mode='compact')
 
-smesh <- inla.mesh.2d(cbind(0,0), max.edge=5, offset=2)
-tmesh <- inla.mesh.1d(0:5)
+smesh <- fm_mesh_2d(cbind(0,0), max.edge=5, offset=2)
+tmesh <- fm_mesh_1d(0:5)
 
 n <- 5
 dataf <- data.frame(
@@ -39,12 +39,12 @@ cat("Number of non-zeros in Q_u:",
 lkprec <- list(prec=list(initial=10, fixed=FALSE))
 
 ### fit
-result <- 
-    bru(M, 
-        like(formula = y ~ ., 
+result <-
+    bru(M,
+        like(formula = y ~ .,
              family="gaussian",
              control.family = list(
-                 hyper = lkprec), 
+                 hyper = lkprec),
              data=dataf),
         options = list(
             num.threads = "2:1")

--- a/inst/tests/fem_comparison.R
+++ b/inst/tests/fem_comparison.R
@@ -25,14 +25,14 @@ ggplot() + theme_minimal() +
     geom_sf(data = bar, fill = "blue")
 
 for(r in sqrt(c(30,20,15,10, 7, 5, 3:1))) {
-    mesh <- inla.mesh.2d(
+    mesh <- fm_mesh_2d(
         loc.domain = pl,
         offset = c(1, 5),
         max.edge = c(r/3, r),
         cutoff = r/6)
     cat("n(mesh) =", mesh$n, "\n")
     print(mark(
-        inla.mesh.fem(mesh),
+        fm_fem(mesh),
         mesh2fem.barrier(mesh, unlist(fm_contains(bar, mesh))),
         check = FALSE
     ))

--- a/inst/tests/precision.R
+++ b/inst/tests/precision.R
@@ -16,7 +16,7 @@ domain <- cbind(
     y = bb[c(2, 2, 4, 4, 2)])
 
 ## spatial mesh
-smesh <- inla.mesh.2d(###fm_mesh_2d(
+smesh <- fm_mesh_2d(
     loc.domain = domain,
     offset = r0 / c(5, 2), ##r0 / c(40, 3),
     max.edge = r0 / c(2, 1), ##c(r0 / c(20, 5),
@@ -27,8 +27,7 @@ if(FALSE)
     plot(smesh)
 
 ## temporal mesh
-tmesh <- inla.mesh.1d(
-    loc = 1:nt)
+tmesh <- fm_mesh_1d(loc = 1:nt)
 
 ## model parameters
 params <- c(

--- a/inst/tests/variance.R
+++ b/inst/tests/variance.R
@@ -7,7 +7,7 @@ sphere <- !FALSE
 outer(1:2, c(3,1,0.3), function(a,b) sqrt(8*a)/b)
 
 lpars0 <- list(
-    srange = log(c(1, 3, 10)), 
+    srange = log(c(1, 3, 10)),
     trange = log(c(5,20)),
     sigma = seq(-3, 3, 1))
 
@@ -20,13 +20,13 @@ sapply(lpars0, function(b) range(exp(b)))
 str(upars <- expand.grid(lpars0))
 
 nt <- 20
-tmesh <- inla.mesh.1d(1:nt)
+tmesh <- fm_mesh_1d(1:nt)
 
 if(sphere){
-    smesh <- inla.mesh.create(globe = 10)
+    smesh <- fm_rcdt_2d_inla(globe = 10)
 } else {
-    smesh <- inla.mesh.2d(
-        loc.domain = c(0,0), 
+    smesh <- fm_mesh_2d(
+        loc.domain = c(0,0),
         offset = 2,
         max.edge = 0.2,
         n = 4

--- a/man/bru_get_mapper.stModel_cgeneric.Rd
+++ b/man/bru_get_mapper.stModel_cgeneric.Rd
@@ -5,7 +5,7 @@
 \alias{bru_get_mapper}
 \title{Mapper object for automatic inlabru interface}
 \usage{
-bru_get_mapper.stModel_cgeneric(model, ...)
+\method{bru_get_mapper}{stModel_cgeneric}(model, ...)
 }
 \arguments{
 \item{model}{The model object (of class \code{stModel_cgeneric}, from

--- a/man/mesh2d.Rd
+++ b/man/mesh2d.Rd
@@ -27,7 +27,8 @@ use the \pkg{fmesher} package.
 }
 \section{Warning}{
 
-This is just for illustration purpose and one should consider the
-efficient function available a the INLA package.
+This is just for illustration purposes and one should consider the
+efficient function \code{\link[fmesher:fm_mesh_2d]{fmesher::fm_mesh_2d()}} (and other related functions)
+available a the fmesher package.
 }
 

--- a/man/mesh2projector.Rd
+++ b/man/mesh2projector.Rd
@@ -33,7 +33,7 @@ Creates a projector matrix object.
 \section{Warning}{
 
 This is just for illustration purpose and one should consider the
-efficient functions available in the INLA and inlabru packages,
-e.g. \code{inlabru::fm_evaluator}.
+efficient functions available in the fmesher package,
+e.g. \code{\link[fmesher:fm_evaluate]{fmesher::fm_evaluator()}} and \code{\link[fmesher:fm_basis]{fmesher::fm_basis()}}.
 }
 

--- a/vignettes/web/barrierExample.Rmd
+++ b/vignettes/web/barrierExample.Rmd
@@ -124,6 +124,7 @@ library(INLA)
 library(INLAspacetime)
 library(inlabru)
 library(patchwork)
+library(fmesher)
 ```
 
 
@@ -145,7 +146,7 @@ the simplest one is using triangles.
 Therefore we start with the following mesh made up of small triangles 
 in the domain and bigger around it.
 ```{r mesh}
-mesh <- inla.mesh.2d(
+mesh <- fm_mesh_2d(
     loc.domain = domain.xy, 
     max.edge = c(0.03, 0.1) * r,
     offset = c(0.1, 0.3) * r,
@@ -157,7 +158,7 @@ The solution needs the triangles inside the barrier domain to be identified.
 For each triangle center we check if it is inside or not of the barrier domain
 and and create a vector to identify to which domain is each triangle center inside
 ```{r ibarrier}
-triBarrier <- unlist(fmesher::fm_contains(
+triBarrier <- unlist(fm_contains(
   x = barriers, 
   y = mesh, 
   type = "centroid"))
@@ -242,12 +243,16 @@ from the location to "everywhere".
 Let us build a projector to project any vector from the mesh nodes to a fine grid
 and projected with
 ```{r pgrid}
-pgrid <- inla.mesh.projector(
+pgrid <- fm_evaluator(
+  mesh,
+  lattice = fm_evaluator_lattice(
     mesh,
     xlim = bb[1, ],
     ylim = bb[2, ],
-    dims = round(500 * rxy/r)) 
-gcorrels <- as.matrix(inla.mesh.project(
+    dims = round(500 * rxy/r)
+  )
+)
+gcorrels <- as.matrix(fm_evaluate(
   pgrid, field = mcorrels
 ))
 ```
@@ -312,7 +317,7 @@ u <- inla.qsample(1, Q, seed = 1)[,1]
 These values sampled at the mesh nodes can be projected to a set of small pixels 
 for visualization purpose with
 ```{r usimgrid}
-ugrid.sim <- inla.mesh.project(pgrid, field = u)
+ugrid.sim <- fm_evaluate(pgrid, field = u)
 ```
 
 We can now visualize the projected simulated values at the small pixels, 
@@ -366,7 +371,7 @@ add an intercept and some random noise
 sigma.e <- 1
 set.seed(3)
 dataset$outcome <- 
-    drop(inla.mesh.project(
+    drop(fm_evaluate(
         mesh,
         loc = cbind(dataset$x, dataset$y),
         field = u)) + 
@@ -479,11 +484,11 @@ The posterior mean and the standard deviation can be projected into small pixels
 and added to the raster data with
 ```{r umean}
 grid.df$u.mean <- as.vector(
-  inla.mesh.project(
+  fm_evaluate(
     pgrid,
     result$summary.random$field$mean))
 grid.df$u.sd <- as.vector(
-  inla.mesh.project(
+  fm_evaluate(
     pgrid,
     result$summary.random$field$sd))
 ``` 

--- a/vignettes/web/piemonte.Rmd
+++ b/vignettes/web/piemonte.Rmd
@@ -47,6 +47,7 @@ library(patchwork)
 library(INLA)
 library(INLAspacetime)
 library(inlabru)
+library(fmesher)
 ```
 
 We will ask it to return the WAIC, DIC and CPO 
@@ -144,7 +145,7 @@ where `h = 1` means one per day.
 ```{r tmesh}
 nt <- max(pdata$time)
 h <- 1
-tmesh <- inla.mesh.1d(
+tmesh <- fm_mesh_1d(
   loc = seq(1, nt + h/2, h), 
   degree = 1)
 tmesh$n
@@ -152,7 +153,7 @@ tmesh$n
 
 Define a spatial mesh, the same used in @cameletti2013.
 ```{r smesh}
-smesh <- inla.mesh.2d(
+smesh <- fm_mesh_2d(
     cbind(locs[,2], locs[,3]),
     loc.domain = pborders,
     max.edge = c(50, 300),


### PR DESCRIPTION
Convert outdated INLA mesh code to fmesher calls, to prepare for upcoming deprecation updates in INLA